### PR TITLE
Correctly convert surrogate UTF-16 to rune on MS-Windows

### DIFF
--- a/internal/win32/util.go
+++ b/internal/win32/util.go
@@ -15,6 +15,17 @@ func hiword(x uint32) uint16 {
 	return uint16((x >> 16) & 0xFFFF)
 }
 
+func isSurrogatedCharacter(x uint32) bool {
+	return x > 0xd800
+}
+
+// surrogatedUtf16toRune recovers code points from high and low surrogates
+func surrogatedUtf16toRune(high uint32, low uint32) rune {
+	high -= 0xd800
+	low -= 0xdc00
+	return rune(high<<10) + rune(low) + rune(0x10000)
+}
+
 func decodeUtf16(s uint16) rune {
 	const (
 		// 0xd800-0xdc00 encodes the high 10 bits of a pair.

--- a/internal/win32/util.go
+++ b/internal/win32/util.go
@@ -15,37 +15,13 @@ func hiword(x uint32) uint16 {
 	return uint16((x >> 16) & 0xFFFF)
 }
 
-func isSurrogatedCharacter(x uint32) bool {
-	return x > 0xd800
+func isSurrogatedCharacter(x rune) bool {
+	return x > 0xd800 // Surrogate characters are mounted after 0xd800
 }
 
 // surrogatedUtf16toRune recovers code points from high and low surrogates
-func surrogatedUtf16toRune(high uint32, low uint32) rune {
+func surrogatedUtf16toRune(high rune, low rune) rune {
 	high -= 0xd800
 	low -= 0xdc00
-	return rune(high<<10) + rune(low) + rune(0x10000)
-}
-
-func decodeUtf16(s uint16) rune {
-	const (
-		// 0xd800-0xdc00 encodes the high 10 bits of a pair.
-		// 0xdc00-0xe000 encodes the low 10 bits of a pair.
-		// the value is those 20 bits plus 0x10000.
-		surr1 = 0xd800
-		surr3 = 0xe000
-
-		// Unicode replacement character
-		replacementChar = '\uFFFD'
-	)
-
-	var a rune
-	switch r := s; {
-	case r < surr1, surr3 <= r:
-		// normal rune
-		a = rune(r)
-	default:
-		// invalid surrogate sequence
-		a = replacementChar
-	}
-	return a
+	return (high << 10) + low + 0x10000
 }


### PR DESCRIPTION
Hi,

I was looking for a window client library for Windows/Mac/Linux written in Go that people around the world can use with confidence, that is, can accurately input multiple languages with IME, and I found your project.

Your library doesn't support IME, but I plan to implement it.
First, as a simple fix, I implemented a fix that allows MS-Windows to accurately transfer characters that occur in UTF-16 surrogate pairs to the application.

```
CursorMoved: physicalX=1280 physicalY=750
KeyboardInput: state=Pressed scanCode=28 virtualKeyCode=e5
ReceivedCharacter: U+29E3D '𩸽'
KeyboardInput: state=Released scanCode=28 virtualKeyCode=Return
```